### PR TITLE
feat: better support for multiple servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,24 @@ Removes a server from the status monitor.
 |------------------------------|-----------------------------------------------------------------------|----------|
 | `server-status-monitor-id`   | The id of the server status monitor.                                  | `true`   |
 
+### `/get-server-details`
+
+Gets all the configuration details for the specified server.
+
+| Parameter                    | Description                                                           | Required |
+|------------------------------|-----------------------------------------------------------------------|----------|
+| `server-status-monitor-id`   | The id of the server status monitor.                                  | `true`   |
+
 ## Configuration Properties
 
-| Property                | Type     | Description                                                                                                                      | Default value          |
-|-------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| `bot.discord-bot-token` | String   | The token for the discord bot. You can find this in the [discord developer portal](https://discord.com/developers/applications). | `null`                 |
-| `bot.database-path`     | Path     | The path to the database file. Should be overwritten when running inside a docker container.                                     | `./bot.db`             |
-| `bot.database-username` | String   | The username for the database.                                                                                                   | `v-rising-discord-bot` |
-| `bot.database-password` | String   | The password for the database.                                                                                                   | `null`                 |
-| `bot.update-delay`      | Duration | The delay between status monitor updates. At least 30 seconds.                                                                   | `1m`                   |
+| Property                  | Type     | Description                                                                                                                      | Default value          |
+|---------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `bot.discord-bot-token`   | String   | The token for the discord bot. You can find this in the [discord developer portal](https://discord.com/developers/applications). | `null`                 |
+| `bot.database-path`       | Path     | The path to the database file. Should be overwritten when running inside a docker container.                                     | `./bot.db`             |
+| `bot.database-username`   | String   | The username for the database.                                                                                                   | `v-rising-discord-bot` |
+| `bot.database-password`   | String   | The password for the database.                                                                                                   | `null`                 |
+| `bot.update-delay`        | Duration | The delay between status monitor updates. At least 30 seconds.                                                                   | `1m`                   |
+| `bot.max-failed-attempts` | Int      | The maximum amount of attempts to be made until a server is disabled. Use `0` if you don't want to use this feature.             | `0`                    |
 
 ## How to run it yourself using docker-compose
 
@@ -67,7 +76,7 @@ Find the latest docker image [here](https://github.com/DarkAtra/v-rising-discord
 ```yaml
 services:
   v-rising-discord-bot:
-    image: ghcr.io/darkatra/v-rising-discord-bot:1.5.4
+    image: ghcr.io/darkatra/v-rising-discord-bot:1.7.7
     volumes:
       - /opt/v-rising-discord-bot:/data/v-rising-discord-bot
     environment:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Find the latest docker image [here](https://github.com/DarkAtra/v-rising-discord
 ```yaml
 services:
   v-rising-discord-bot:
-    image: ghcr.io/darkatra/v-rising-discord-bot:1.7.7
+    image: ghcr.io/darkatra/v-rising-discord-bot:1.8.0
     volumes:
       - /opt/v-rising-discord-bot:/data/v-rising-discord-bot
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>de.darkatra</groupId>
     <artifactId>v-rising-discord-bot</artifactId>
-    <version>1.7.6</version>
+    <version>1.8.0</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/src/main/kotlin/de/darkatra/vrising/discord/BotProperties.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/BotProperties.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.validation.annotation.Validated
 import java.nio.file.Path
 import java.time.Duration
+import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 
@@ -29,4 +30,8 @@ class BotProperties {
     @field:NotNull
     @field:DurationMin(seconds = 30)
     lateinit var updateDelay: Duration
+
+    @field:Min(0)
+    @field:NotNull
+    var maxFailedAttempts: Int = 0
 }

--- a/src/main/kotlin/de/darkatra/vrising/discord/ServerStatusMonitor.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/ServerStatusMonitor.kt
@@ -23,6 +23,7 @@ data class ServerStatusMonitor(
     val displayServerDescription: Boolean,
 
     var currentEmbedMessageId: String? = null,
+    var currentFailedAttempts: Int = 0,
 ) {
 
     fun builder(): ServerStatusMonitorBuilder {
@@ -34,7 +35,8 @@ data class ServerStatusMonitor(
             queryPort = queryPort,
             status = status,
             displayServerDescription = displayServerDescription,
-            currentEmbedMessageId = currentEmbedMessageId
+            currentEmbedMessageId = currentEmbedMessageId,
+            currentFailedAttempts = currentFailedAttempts
         )
     }
 }
@@ -50,6 +52,7 @@ class ServerStatusMonitorBuilder(
     var displayServerDescription: Boolean,
 
     var currentEmbedMessageId: String? = null,
+    var currentFailedAttempts: Int,
 ) {
 
     fun build(): ServerStatusMonitor {
@@ -61,7 +64,8 @@ class ServerStatusMonitorBuilder(
             queryPort = queryPort,
             status = status,
             displayServerDescription = displayServerDescription,
-            currentEmbedMessageId = currentEmbedMessageId
+            currentEmbedMessageId = currentEmbedMessageId,
+            currentFailedAttempts = currentFailedAttempts
         )
     }
 }

--- a/src/main/kotlin/de/darkatra/vrising/discord/ServerStatusMonitorService.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/ServerStatusMonitorService.kt
@@ -64,53 +64,89 @@ class ServerStatusMonitorService(
         }
     }
 
+    fun disableServerStatusMonitor(serverStatusMonitor: ServerStatusMonitor) {
+        putServerStatusMonitor(
+            serverStatusMonitor.builder().also {
+                it.status = ServerStatusMonitorStatus.INACTIVE
+            }.build()
+        )
+    }
+
     fun launchServerStatusMonitor(kord: Kord) {
         launch {
             while (isActive) {
-                getServerStatusMonitors(status = ServerStatusMonitorStatus.ACTIVE).forEach { serverStatusConfiguration ->
+                getServerStatusMonitors(status = ServerStatusMonitorStatus.ACTIVE).forEach { serverStatusMonitor ->
                     runCatching {
 
-                        val channel = kord.getChannel(Snowflake(serverStatusConfiguration.discordChannelId))
+                        val channel = kord.getChannel(Snowflake(serverStatusMonitor.discordChannelId))
                         if (channel == null || channel !is MessageChannelBehavior) {
                             logger.debug(
-                                """Skipping server monitor '${serverStatusConfiguration.id}' because the channel
-                                |'${serverStatusConfiguration.discordChannelId}' does not seem to exist""".trimMargin()
+                                """Disabling server monitor '${serverStatusMonitor.id}' because the channel
+                                |'${serverStatusMonitor.discordChannelId}' does not seem to exist""".trimMargin()
                             )
+                            disableServerStatusMonitor(serverStatusMonitor)
                             return@forEach
                         }
 
-                        val serverInfo = serverQueryClient.getServerInfo(serverStatusConfiguration.hostName, serverStatusConfiguration.queryPort)
-                        val players = serverQueryClient.getPlayerList(serverStatusConfiguration.hostName, serverStatusConfiguration.queryPort)
-                        val rules = serverQueryClient.getRules(serverStatusConfiguration.hostName, serverStatusConfiguration.queryPort)
+                        val serverInfo = serverQueryClient.getServerInfo(serverStatusMonitor.hostName, serverStatusMonitor.queryPort)
+                        val players = serverQueryClient.getPlayerList(serverStatusMonitor.hostName, serverStatusMonitor.queryPort)
+                        val rules = serverQueryClient.getRules(serverStatusMonitor.hostName, serverStatusMonitor.queryPort)
 
                         val embedCustomizer: (embedBuilder: EmbedBuilder) -> Unit = { embedBuilder ->
                             ServerStatusEmbed.buildEmbed(
                                 serverInfo,
                                 players,
                                 rules,
-                                serverStatusConfiguration.displayServerDescription,
+                                serverStatusMonitor.displayServerDescription,
                                 embedBuilder
                             )
                         }
 
-                        val currentEmbedMessageId = serverStatusConfiguration.currentEmbedMessageId
+                        val currentEmbedMessageId = serverStatusMonitor.currentEmbedMessageId
                         if (currentEmbedMessageId != null) {
                             try {
                                 channel.getMessage(Snowflake(currentEmbedMessageId))
                                     .edit { embed(embedCustomizer) }
-                                logger.debug("Successfully updated the status of server monitor: ${serverStatusConfiguration.id}")
+
+                                serverStatusMonitor.currentFailedAttempts = 0
+                                putServerStatusMonitor(serverStatusMonitor)
+
+                                logger.debug("Successfully updated the status of server monitor: ${serverStatusMonitor.id}")
                                 return@forEach
                             } catch (e: EntityNotFoundException) {
-                                serverStatusConfiguration.currentEmbedMessageId = null
+                                serverStatusMonitor.currentEmbedMessageId = null
                             }
                         }
 
-                        serverStatusConfiguration.currentEmbedMessageId = channel.createEmbed(embedCustomizer).id.toString()
-                        putServerStatusMonitor(serverStatusConfiguration)
-                        logger.debug("Successfully updated the status and persisted the embedId of server monitor: ${serverStatusConfiguration.id}")
+                        serverStatusMonitor.currentEmbedMessageId = channel.createEmbed(embedCustomizer).id.toString()
+                        serverStatusMonitor.currentFailedAttempts = 0
+                        putServerStatusMonitor(serverStatusMonitor)
+
+                        logger.debug("Successfully updated the status and persisted the embedId of server monitor: ${serverStatusMonitor.id}")
 
                     }.onFailure { throwable ->
-                        logger.error("Exception while fetching the status of ${serverStatusConfiguration.id}", throwable)
+                        logger.error("Exception while fetching the status of ${serverStatusMonitor.id}", throwable)
+                        serverStatusMonitor.currentFailedAttempts += 1
+                        putServerStatusMonitor(serverStatusMonitor)
+
+                        if (botProperties.maxFailedAttempts != 0 && serverStatusMonitor.currentFailedAttempts >= botProperties.maxFailedAttempts) {
+                            logger.debug("Disabling server monitor '${serverStatusMonitor.id}' because it exceeded the max failed attempts.")
+                            disableServerStatusMonitor(serverStatusMonitor)
+
+                            val channel = kord.getChannel(Snowflake(serverStatusMonitor.discordChannelId))
+                            if (channel == null || channel !is MessageChannelBehavior) {
+                                return@forEach
+                            }
+
+                            channel.createMessage(
+                                """Disabled server status monitor '${serverStatusMonitor.id}' because the server did not
+                                |respond after ${botProperties.maxFailedAttempts} attempts.
+                                |Please make sure the server is running and is accessible from the internet to use this bot.
+                                |You can re-enable the server status monitor with the update-server command.""".trimMargin()
+                            )
+
+                            return@forEach
+                        }
                     }
                 }
 

--- a/src/main/kotlin/de/darkatra/vrising/discord/command/GetServerDetailsCommand.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/command/GetServerDetailsCommand.kt
@@ -1,0 +1,103 @@
+package de.darkatra.vrising.discord.command
+
+import de.darkatra.vrising.discord.ServerStatusMonitorService
+import de.darkatra.vrising.discord.command.parameter.addServerStatusMonitorIdParameter
+import de.darkatra.vrising.discord.command.parameter.getServerStatusMonitorIdParameter
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.entity.interaction.GuildChatInputCommandInteraction
+import dev.kord.rest.builder.message.modify.embed
+import org.springframework.stereotype.Component
+
+@Component
+class GetServerDetailsCommand(
+    private val serverStatusMonitorService: ServerStatusMonitorService,
+) : Command {
+
+    private val name: String = "get-server-details"
+    private val description: String = "Gets all the configuration details for the specified server."
+
+    override fun getCommandName(): String = name
+
+    override suspend fun register(kord: Kord) {
+
+        kord.createGlobalChatInputCommand(
+            name = name,
+            description = description
+        ) {
+            dmPermission = false
+            disableCommandInGuilds()
+
+            addServerStatusMonitorIdParameter()
+        }
+    }
+
+    override suspend fun handle(interaction: ChatInputCommandInteraction) {
+
+        val serverStatusMonitorId = interaction.getServerStatusMonitorIdParameter()
+        val discordServerId = (interaction as GuildChatInputCommandInteraction).guildId
+
+        val serverStatusMonitor = serverStatusMonitorService.getServerStatusMonitor(serverStatusMonitorId, discordServerId.toString())
+        if (serverStatusMonitor == null) {
+            interaction.deferEphemeralResponse().respond {
+                content = "No server with id '$serverStatusMonitorId' was found."
+            }
+            return
+        }
+
+        interaction.deferEphemeralResponse().respond {
+            embed {
+                title = "Details for ${serverStatusMonitor.id}"
+
+                field {
+                    name = "Hostname"
+                    value = serverStatusMonitor.hostName
+                    inline = true
+                }
+
+                field {
+                    name = "Query Port"
+                    value = "${serverStatusMonitor.queryPort}"
+                    inline = true
+                }
+
+                field {
+                    name = "Display Server Description"
+                    value = "${serverStatusMonitor.displayServerDescription}"
+                    inline = true
+                }
+
+                field {
+                    name = "Status"
+                    value = serverStatusMonitor.status.name
+                    inline = true
+                }
+
+                field {
+                    name = "Discord Server Id"
+                    value = serverStatusMonitor.discordServerId
+                    inline = true
+                }
+
+                field {
+                    name = "Discord Channel Id"
+                    value = serverStatusMonitor.discordChannelId
+                    inline = true
+                }
+
+                field {
+                    name = "Current Embed Message Id"
+                    value = serverStatusMonitor.currentEmbedMessageId ?: "-"
+                    inline = true
+                }
+
+                field {
+                    name = "Current Failed Attempts"
+                    value = "${serverStatusMonitor.currentFailedAttempts}"
+                    inline = true
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationService.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationService.kt
@@ -39,7 +39,11 @@ class DatabaseMigrationService(
                 // setting it to false instead (this was the default value in previous versions)
                 document["displayPlayerGearLevel"] = false
             }
-        )
+        ),
+        DatabaseMigration(
+            isApplicable = { currentSchemaVersion -> currentSchemaVersion.major == 1 && currentSchemaVersion.minor <= 7 },
+            action = { document -> document["currentFailedAttempts"] = 0 }
+        ),
     )
 
     fun migrateToLatestVersion(): Boolean {

--- a/src/test/kotlin/de/darkatra/vrising/discord/BotPropertiesTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/BotPropertiesTest.kt
@@ -73,6 +73,19 @@ internal class BotPropertiesTest {
         assertThat(result).hasSize(1)
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = [-99, -1])
+    internal fun `should be invalid if maxFailedAttempts is below 1`(maxFailedAttempts: Int) {
+
+        val botProperties = getValidBotProperties().apply {
+            this.maxFailedAttempts = maxFailedAttempts
+        }
+
+        val result = validator.validate(botProperties)
+
+        assertThat(result).hasSize(1)
+    }
+
     private fun getValidBotProperties(): BotProperties {
         return BotProperties().apply {
             discordBotToken = "discord-token"
@@ -80,6 +93,7 @@ internal class BotPropertiesTest {
             databaseUsername = "username"
             databasePassword = "password"
             updateDelay = Duration.ofSeconds(30)
+            maxFailedAttempts = 5
         }
     }
 }

--- a/src/test/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationServiceTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationServiceTest.kt
@@ -39,15 +39,16 @@ internal class DatabaseMigrationServiceTest {
         repository.insert(Schema(appVersion = "V1.4.0"))
         repository.insert(Schema(appVersion = "V1.5.0"))
         repository.insert(Schema(appVersion = "V1.6.0"))
+        repository.insert(Schema(appVersion = "V1.8.0"))
 
         val databaseMigrationService = DatabaseMigrationService(
             database = database,
-            appVersionFromPom = "1.6.0"
+            appVersionFromPom = "1.8.0"
         )
 
         assertThat(databaseMigrationService.migrateToLatestVersion()).isFalse
 
         val schemas = repository.find().toList()
-        assertThat(schemas).hasSize(3)
+        assertThat(schemas).hasSize(4)
     }
 }


### PR DESCRIPTION
# Description

Improves support for handling multiple servers (and even multiple discord servers).

* automatically disable servers after n attempts
* new command to list all settings for a given server status monitor configuration

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I hereby accept that the code I contributed is under the MIT license.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
