### PR TITLE
feat(gh-95): allow rejecting ips from reserved ranges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         run: echo "image-name=$(mvn help:evaluate -Dexpression=image.name -q -DforceStdout)" >> $GITHUB_OUTPUT
 
       - name: Scan Docker Image for Vulnerabilities
-        uses: aquasecurity/trivy-action@0.11.2
+        uses: aquasecurity/trivy-action@0.12.0
         with:
           image-ref: ${{ steps.get-image-name.outputs.image-name }}
           format: sarif

--- a/.github/workflows/scan-docker-image.yml
+++ b/.github/workflows/scan-docker-image.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "image-name=$(mvn help:evaluate -Dexpression=image.name -q -DforceStdout)" >> $GITHUB_OUTPUT
 
       - name: Scan Docker Image for Vulnerabilities
-        uses: aquasecurity/trivy-action@0.11.2
+        uses: aquasecurity/trivy-action@0.12.0
         with:
           image-ref: ${{ steps.get-image-name.outputs.image-name }}
           format: sarif

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/README.md
+++ b/README.md
@@ -68,16 +68,17 @@ Gets all the configuration details for the specified server.
 
 ## Configuration Properties
 
-| Property                       | Type     | Description                                                                                                                      | Default value          |
-|--------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| `bot.discord-bot-token`        | String   | The token for the discord bot. You can find this in the [discord developer portal](https://discord.com/developers/applications). | `null`                 |
-| `bot.database-path`            | Path     | The path to the database file. Should be overwritten when running inside a docker container.                                     | `./bot.db`             |
-| `bot.database-username`        | String   | The username for the database.                                                                                                   | `v-rising-discord-bot` |
-| `bot.database-password`        | String   | The password for the database.                                                                                                   | `null`                 |
-| `bot.update-delay`             | Duration | The delay between status monitor updates. At least 30 seconds.                                                                   | `1m`                   |
-| `bot.max-failed-attempts`      | Int      | The maximum number of attempts to be made until a server is disabled. Use `0` if you don't want to use this feature.             | `0`                    |
-| `bot.max-recent-errors`        | Int      | The maximum number of errors to keep for debugging via `/get-server-details`. Use `0` if you don't want to use this feature.     | `5`                    |
-| `bot.max-characters-per-error` | Int      | The maximum number of errors to keep for debugging via `/get-server-details`. Use `0` if you don't want to use this feature.     | `200`                  |
+| Property                         | Type     | Description                                                                                                                      | Default value          |
+|----------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `bot.discord-bot-token`          | String   | The token for the discord bot. You can find this in the [discord developer portal](https://discord.com/developers/applications). | `null`                 |
+| `bot.database-path`              | Path     | The path to the database file. Should be overwritten when running inside a docker container.                                     | `./bot.db`             |
+| `bot.database-username`          | String   | The username for the database.                                                                                                   | `v-rising-discord-bot` |
+| `bot.database-password`          | String   | The password for the database.                                                                                                   | `null`                 |
+| `bot.update-delay`               | Duration | The delay between status monitor updates. At least 30 seconds.                                                                   | `1m`                   |
+| `bot.max-failed-attempts`        | Int      | The maximum number of attempts to be made until a server is disabled. Use `0` if you don't want to use this feature.             | `0`                    |
+| `bot.max-recent-errors`          | Int      | The maximum number of errors to keep for debugging via `/get-server-details`. Use `0` if you don't want to use this feature.     | `5`                    |
+| `bot.max-characters-per-error`   | Int      | The maximum number of errors to keep for debugging via `/get-server-details`. Use `0` if you don't want to use this feature.     | `200`                  |
+| `bot.allow-local-address-ranges` | Boolean  | Whether or not addresses from reserved ip ranges are permitted when adding or updating status monitors.                          | `true`                 |
 
 ## [v-rising-discord-bot-companion](https://github.com/DarkAtra/v-rising-discord-bot-companion) Integration
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>de.darkatra</groupId>
     <artifactId>v-rising-discord-bot</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0-next.1</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.4</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>de.darkatra</groupId>
     <artifactId>v-rising-discord-bot</artifactId>
-    <version>2.5.0-next.1</version>
+    <version>2.5.0-next.2</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.4</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
 
         <kord.version>0.10.0</kord.version>
         <agql-source-query.version>1.2.1</agql-source-query.version>
-        <java-uuid-generator.version>4.2.0</java-uuid-generator.version>
+        <java-uuid-generator.version>4.3.0</java-uuid-generator.version>
         <potassium-nitrite.version>3.4.4</potassium-nitrite.version>
         <commons-validator.version>1.7</commons-validator.version>
 

--- a/src/main/kotlin/de/darkatra/vrising/discord/BotProperties.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/BotProperties.kt
@@ -40,4 +40,6 @@ class BotProperties {
     @field:Min(1)
     @field:NotNull
     var maxCharactersPerError: Int = 200
+
+    var allowLocalAddressRanges: Boolean = true
 }

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/AddServerCommand.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/AddServerCommand.kt
@@ -1,6 +1,7 @@
 package de.darkatra.vrising.discord.commands
 
 import com.fasterxml.uuid.Generators
+import de.darkatra.vrising.discord.BotProperties
 import de.darkatra.vrising.discord.commands.parameters.ServerApiHostnameParameter
 import de.darkatra.vrising.discord.commands.parameters.ServerHostnameParameter
 import de.darkatra.vrising.discord.commands.parameters.addDisplayPlayerGearLevelParameter
@@ -26,11 +27,14 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.entity.interaction.GuildChatInputCommandInteraction
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 
 @Component
+@EnableConfigurationProperties(BotProperties::class)
 class AddServerCommand(
     private val serverStatusMonitorRepository: ServerStatusMonitorRepository,
+    private val botProperties: BotProperties
 ) : Command {
 
     private val name: String = "add-server"
@@ -77,8 +81,8 @@ class AddServerCommand(
         val discordServerId = (interaction as GuildChatInputCommandInteraction).guildId
         val channelId = interaction.channelId
 
-        ServerHostnameParameter.validate(hostname)
-        ServerApiHostnameParameter.validate(apiHostname)
+        ServerHostnameParameter.validate(hostname, botProperties.allowLocalAddressRanges)
+        ServerApiHostnameParameter.validate(apiHostname, botProperties.allowLocalAddressRanges)
 
         val serverStatusMonitorId = Generators.timeBasedGenerator().generate()
         serverStatusMonitorRepository.addServerStatusMonitor(

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/GetServerDetailsCommand.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/GetServerDetailsCommand.kt
@@ -9,10 +9,12 @@ import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.entity.interaction.GuildChatInputCommandInteraction
 import dev.kord.rest.builder.message.modify.embed
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
 
 @Component
+@EnableConfigurationProperties(BotProperties::class)
 class GetServerDetailsCommand(
     private val serverStatusMonitorRepository: ServerStatusMonitorRepository,
     private val botProperties: BotProperties

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/UpdateServerCommand.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/UpdateServerCommand.kt
@@ -1,5 +1,6 @@
 package de.darkatra.vrising.discord.commands
 
+import de.darkatra.vrising.discord.BotProperties
 import de.darkatra.vrising.discord.commands.parameters.ServerApiHostnameParameter
 import de.darkatra.vrising.discord.commands.parameters.ServerHostnameParameter
 import de.darkatra.vrising.discord.commands.parameters.addDisplayPlayerGearLevelParameter
@@ -27,11 +28,14 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.entity.interaction.GuildChatInputCommandInteraction
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 
 @Component
+@EnableConfigurationProperties(BotProperties::class)
 class UpdateServerCommand(
     private val serverStatusMonitorRepository: ServerStatusMonitorRepository,
+    private val botProperties: BotProperties
 ) : Command {
 
     private val name: String = "update-server"
@@ -90,7 +94,7 @@ class UpdateServerCommand(
         }
 
         if (hostname != null) {
-            ServerHostnameParameter.validate(hostname)
+            ServerHostnameParameter.validate(hostname, botProperties.allowLocalAddressRanges)
             serverStatusMonitor.hostname = hostname
         }
         if (queryPort != null) {
@@ -98,7 +102,7 @@ class UpdateServerCommand(
         }
         if (apiHostname != null) {
             serverStatusMonitor.apiHostname = determineValueOfNullableStringParameter(apiHostname).also {
-                ServerApiHostnameParameter.validate(it)
+                ServerApiHostnameParameter.validate(it, botProperties.allowLocalAddressRanges)
             }
         }
         if (apiPort != null) {

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/HostnameValidator.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/HostnameValidator.kt
@@ -1,0 +1,26 @@
+package de.darkatra.vrising.discord.commands.parameters
+
+import de.darkatra.vrising.discord.commands.exceptions.ValidationException
+import org.apache.commons.validator.routines.DomainValidator
+import org.apache.commons.validator.routines.InetAddressValidator
+import java.net.InetAddress
+import java.net.UnknownHostException
+
+object HostnameValidator {
+
+    fun validate(hostname: String, allowLocalAddressRanges: Boolean, propertyName: String) {
+        if (!InetAddressValidator.getInstance().isValid(hostname) && !DomainValidator.getInstance(true).isValid(hostname)) {
+            throw ValidationException("'$propertyName' is not a valid ip address or domain name. Rejected: $hostname")
+        }
+        if (!allowLocalAddressRanges) {
+            val resolvedAddress = try {
+                InetAddress.getByName(hostname)
+            } catch (e: UnknownHostException) {
+                throw ValidationException("'$propertyName' could not be resolved. Rejected: $hostname")
+            }
+            if (resolvedAddress.isSiteLocalAddress || resolvedAddress.isLoopbackAddress || resolvedAddress.isLinkLocalAddress) {
+                throw ValidationException("'$propertyName' must be a public ip address. Rejected: $hostname")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerApiHostnameParameter.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerApiHostnameParameter.kt
@@ -1,22 +1,17 @@
 package de.darkatra.vrising.discord.commands.parameters
 
-import de.darkatra.vrising.discord.commands.exceptions.ValidationException
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.rest.builder.interaction.GlobalChatInputCreateBuilder
 import dev.kord.rest.builder.interaction.string
-import org.apache.commons.validator.routines.DomainValidator
-import org.apache.commons.validator.routines.InetAddressValidator
 
 object ServerApiHostnameParameter {
     const val NAME = "server-api-hostname"
 
-    fun validate(serverApiHostname: String?) {
+    fun validate(serverApiHostname: String?, allowLocalAddressRanges: Boolean) {
         if (serverApiHostname == null) {
             return
         }
-        if (!InetAddressValidator.getInstance().isValid(serverApiHostname) && !DomainValidator.getInstance(true).isValid(serverApiHostname)) {
-            throw ValidationException("'$NAME' is not a valid ip address or domain name. Rejected: $serverApiHostname")
-        }
+        HostnameValidator.validate(serverApiHostname, allowLocalAddressRanges, NAME)
     }
 }
 

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerHostnameParameter.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerHostnameParameter.kt
@@ -1,19 +1,14 @@
 package de.darkatra.vrising.discord.commands.parameters
 
-import de.darkatra.vrising.discord.commands.exceptions.ValidationException
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.rest.builder.interaction.GlobalChatInputCreateBuilder
 import dev.kord.rest.builder.interaction.string
-import org.apache.commons.validator.routines.DomainValidator
-import org.apache.commons.validator.routines.InetAddressValidator
 
 object ServerHostnameParameter {
     const val NAME = "server-hostname"
 
-    fun validate(serverHostname: String) {
-        if (!InetAddressValidator.getInstance().isValid(serverHostname) && !DomainValidator.getInstance(true).isValid(serverHostname)) {
-            throw ValidationException("'$NAME' is not a valid ip address or domain name. Rejected: $serverHostname")
-        }
+    fun validate(serverHostname: String, allowLocalAddressRanges: Boolean) {
+        HostnameValidator.validate(serverHostname, allowLocalAddressRanges, NAME)
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,4 @@ bot:
   max-failed-attempts: 0
   max-recent-errors: 5
   max-characters-per-error: 200
+  allow-local-address-ranges: true

--- a/src/test/kotlin/de/darkatra/vrising/discord/commands/parameters/HostnameValidatorTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/commands/parameters/HostnameValidatorTest.kt
@@ -1,0 +1,42 @@
+package de.darkatra.vrising.discord.commands.parameters
+
+import de.darkatra.vrising.discord.commands.exceptions.ValidationException
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class HostnameValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["localhost", "127.0.0.1", "0:0:0:0:0:0:0:1", "::1"])
+    fun `should reject loopback addresses`(hostname: String) {
+        assertThrows<ValidationException> {
+            ServerHostnameParameter.validate(hostname, false)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["10.0.0.1", "172.16.0.1", "192.168.0.1", "FEC0:0:0:0:0:0:0:1"])
+    fun `should reject site local addresses`(hostname: String) {
+        assertThrows<ValidationException> {
+            ServerHostnameParameter.validate(hostname, false)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["169.254.0.1", "169.254.10.1", "fe80:0:0:0:0:0:0:1"])
+    fun `should reject link local addresses`(hostname: String) {
+        assertThrows<ValidationException> {
+            ServerHostnameParameter.validate(hostname, false)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["darkatra.de", "8.8.8.8"])
+    fun `should permit `(hostname: String) {
+        assertDoesNotThrow {
+            ServerHostnameParameter.validate(hostname, false)
+        }
+    }
+}

--- a/src/test/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerApiHostnameParameterTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerApiHostnameParameterTest.kt
@@ -12,39 +12,39 @@ class ServerApiHostnameParameterTest {
     @Test
     fun `should accept null`() {
         assertDoesNotThrow {
-            ServerApiHostnameParameter.validate(null)
+            ServerApiHostnameParameter.validate(null, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["localhost", "darkatra.de"])
-    fun `should accept hostnames`(hostname: String) {
+    fun `should permit hostnames`(hostname: String) {
         assertDoesNotThrow {
-            ServerApiHostnameParameter.validate(hostname)
+            ServerApiHostnameParameter.validate(hostname, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["127.0.0.1", "192.168.178.1"])
-    fun `should accept ip v4 address`(ipv4: String) {
+    fun `should permit ip v4 addresses`(ipv4: String) {
         assertDoesNotThrow {
-            ServerApiHostnameParameter.validate(ipv4)
+            ServerApiHostnameParameter.validate(ipv4, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["0:0:0:0:0:0:0:1", "::1"])
-    fun `should accept ip v6 address`(ipv6: String) {
+    fun `should permit ip v6 addresses`(ipv6: String) {
         assertDoesNotThrow {
-            ServerApiHostnameParameter.validate(ipv6)
+            ServerApiHostnameParameter.validate(ipv6, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["DarkAtra.de - V Rising Duo PvP", "[EU] Official #1234"])
-    fun `should not accept server names`(hostname: String) {
+    fun `should reject server names`(hostname: String) {
         assertThrows<ValidationException> {
-            ServerApiHostnameParameter.validate(hostname)
+            ServerApiHostnameParameter.validate(hostname, false)
         }
     }
 }

--- a/src/test/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerHostnameParameterTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/commands/parameters/ServerHostnameParameterTest.kt
@@ -10,33 +10,33 @@ class ServerHostnameParameterTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["localhost", "darkatra.de"])
-    fun `should accept hostnames`(hostname: String) {
+    fun `should permit hostnames`(hostname: String) {
         assertDoesNotThrow {
-            ServerHostnameParameter.validate(hostname)
+            ServerHostnameParameter.validate(hostname, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["127.0.0.1", "192.168.178.1"])
-    fun `should accept ip v4 address`(ipv4: String) {
+    fun `should permit ip v4 addresses`(ipv4: String) {
         assertDoesNotThrow {
-            ServerHostnameParameter.validate(ipv4)
+            ServerHostnameParameter.validate(ipv4, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["0:0:0:0:0:0:0:1", "::1"])
-    fun `should accept ip v6 address`(ipv6: String) {
+    fun `should permit ip v6 addresses`(ipv6: String) {
         assertDoesNotThrow {
-            ServerHostnameParameter.validate(ipv6)
+            ServerHostnameParameter.validate(ipv6, true)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["DarkAtra.de - V Rising Duo PvP", "[EU] Official #1234"])
-    fun `should not accept server names`(hostname: String) {
+    fun `should reject server names`(hostname: String) {
         assertThrows<ValidationException> {
-            ServerHostnameParameter.validate(hostname)
+            ServerHostnameParameter.validate(hostname, false)
         }
     }
 }


### PR DESCRIPTION
# Description

Introduces a configuration property to allow rejecting ips from reserved ranges such as `192.168.0.0/16`, `10.0.0.0/8` or `127.0.0.0/8`, see https://github.com/DarkAtra/v-rising-discord-bot/issues/95 for details. The new property defaults to allowing all ips so that this does not introduce a breaking change.