### PR TITLE
fix: `/list-servers` now pages the response

### DIFF
--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/ListServersCommand.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/ListServersCommand.kt
@@ -1,6 +1,9 @@
 package de.darkatra.vrising.discord.commands
 
 import de.darkatra.vrising.discord.BotProperties
+import de.darkatra.vrising.discord.commands.parameters.PageParameter
+import de.darkatra.vrising.discord.commands.parameters.addPageParameter
+import de.darkatra.vrising.discord.commands.parameters.getPageParameter
 import de.darkatra.vrising.discord.serverstatus.ServerStatusMonitorRepository
 import de.darkatra.vrising.discord.serverstatus.model.ServerStatusMonitor
 import dev.kord.core.Kord
@@ -10,6 +13,8 @@ import dev.kord.core.entity.interaction.GlobalChatInputCommandInteraction
 import dev.kord.core.entity.interaction.GuildChatInputCommandInteraction
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
+
+private const val PAGE_SIZE = 10
 
 @Component
 @EnableConfigurationProperties(BotProperties::class)
@@ -30,14 +35,40 @@ class ListServersCommand(
         ) {
             dmPermission = true
             disableCommandInGuilds()
+
+            addPageParameter(required = false)
         }
     }
 
     override suspend fun handle(interaction: ChatInputCommandInteraction) {
 
+        val page = interaction.getPageParameter() ?: 0
+        PageParameter.validate(page)
+
+        val totalElements = when (interaction) {
+            is GuildChatInputCommandInteraction -> serverStatusMonitorRepository.count(interaction.guildId.toString())
+            is GlobalChatInputCommandInteraction -> serverStatusMonitorRepository.count()
+        }
+        val totalPages = totalElements / PAGE_SIZE + 1
+
+        if (page >= totalPages) {
+            interaction.deferEphemeralResponse().respond {
+                content = "This page does not exist."
+            }
+            return
+        }
+
         val serverStatusMonitors: List<ServerStatusMonitor> = when (interaction) {
-            is GuildChatInputCommandInteraction -> serverStatusMonitorRepository.getServerStatusMonitors(interaction.guildId.toString())
-            is GlobalChatInputCommandInteraction -> serverStatusMonitorRepository.getServerStatusMonitors()
+            is GuildChatInputCommandInteraction -> serverStatusMonitorRepository.getServerStatusMonitors(
+                discordServerId = interaction.guildId.toString(),
+                offset = page * PAGE_SIZE,
+                limit = PAGE_SIZE
+            )
+
+            is GlobalChatInputCommandInteraction -> serverStatusMonitorRepository.getServerStatusMonitors(
+                offset = page * PAGE_SIZE,
+                limit = PAGE_SIZE
+            )
         }
 
         interaction.deferEphemeralResponse().respond {
@@ -45,7 +76,7 @@ class ListServersCommand(
                 true -> "No servers found."
                 false -> serverStatusMonitors.joinToString(separator = "\n") { serverStatusMonitor ->
                     "${serverStatusMonitor.id} - ${serverStatusMonitor.hostname}:${serverStatusMonitor.queryPort} - ${serverStatusMonitor.status.name}"
-                }
+                } + "\n*Current Page: $page, Total Pages: $totalPages*"
             }
         }
     }

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/PageParameter.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/parameters/PageParameter.kt
@@ -1,0 +1,29 @@
+package de.darkatra.vrising.discord.commands.parameters
+
+import de.darkatra.vrising.discord.commands.exceptions.ValidationException
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.rest.builder.interaction.GlobalChatInputCreateBuilder
+import dev.kord.rest.builder.interaction.integer
+
+object PageParameter {
+    const val NAME = "page"
+
+    fun validate(page: Int) {
+        if (page < 0) {
+            throw ValidationException("'$NAME' must be greater than or equal to zero. Rejected: $page")
+        }
+    }
+}
+
+fun GlobalChatInputCreateBuilder.addPageParameter(required: Boolean = true) {
+    integer(
+        name = PageParameter.NAME,
+        description = "The page. Defaults to 0, the first page."
+    ) {
+        this.required = required
+    }
+}
+
+fun ChatInputCommandInteraction.getPageParameter(): Int? {
+    return command.integers[PageParameter.NAME]?.let { Math.toIntExact(it) }
+}


### PR DESCRIPTION
Discord has a message size limit. The `/list-servers` command can potentially exceed this limit if there are a lot of servers registered. This PR introduces paging, so that this does not happen.