### PR TITLE
fix: execute server queries in parallel

### DIFF
--- a/src/main/kotlin/de/darkatra/vrising/discord/clients/serverquery/model/ServerStatus.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/clients/serverquery/model/ServerStatus.kt
@@ -1,0 +1,10 @@
+package de.darkatra.vrising.discord.clients.serverquery.model
+
+import com.ibasco.agql.protocols.valve.source.query.info.SourceServer
+import com.ibasco.agql.protocols.valve.source.query.players.SourcePlayer
+
+data class ServerStatus(
+    val serverInfo: SourceServer,
+    val players: List<SourcePlayer>,
+    val rules: Map<String, String>
+)

--- a/src/main/kotlin/de/darkatra/vrising/discord/serverstatus/ServerInfoResolver.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/serverstatus/ServerInfoResolver.kt
@@ -20,9 +20,7 @@ class ServerInfoResolver(
 
     suspend fun getServerInfo(serverStatusMonitor: ServerStatusMonitor): ServerInfo {
 
-        val serverInfo = serverQueryClient.getServerInfo(serverStatusMonitor.hostname, serverStatusMonitor.queryPort)
-        val players = serverQueryClient.getPlayerList(serverStatusMonitor.hostname, serverStatusMonitor.queryPort)
-        val rules = serverQueryClient.getRules(serverStatusMonitor.hostname, serverStatusMonitor.queryPort)
+        val serverStatus = serverQueryClient.getServerStatus(serverStatusMonitor.hostname, serverStatusMonitor.queryPort)
         val characters = when {
             serverStatusMonitor.apiEnabled -> botCompanionClient.getCharacters(
                 serverStatusMonitor.apiHostname!!,
@@ -34,13 +32,13 @@ class ServerInfoResolver(
         }
 
         return ServerInfo(
-            name = serverInfo.name,
-            ip = serverInfo.hostAddress,
-            gamePort = serverInfo.gamePort,
-            queryPort = serverInfo.port,
-            numberOfPlayers = serverInfo.numOfPlayers,
-            maxPlayers = serverInfo.maxPlayers,
-            players = players.map { sourcePlayer ->
+            name = serverStatus.serverInfo.name,
+            ip = serverStatus.serverInfo.hostAddress,
+            gamePort = serverStatus.serverInfo.gamePort,
+            queryPort = serverStatus.serverInfo.port,
+            numberOfPlayers = serverStatus.serverInfo.numOfPlayers,
+            maxPlayers = serverStatus.serverInfo.maxPlayers,
+            players = serverStatus.players.map { sourcePlayer ->
                 val character = characters.find { character -> character.name == sourcePlayer.name }
                 Player(
                     name = sourcePlayer.name,
@@ -49,7 +47,7 @@ class ServerInfoResolver(
                     killedVBloods = character?.killedVBloods?.map(VBlood::displayName)
                 )
             },
-            rules = rules
+            rules = serverStatus.rules
         )
     }
 

--- a/src/test/kotlin/de/darkatra/vrising/discord/clients/botcompanion/BotCompanionClientTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/clients/botcompanion/BotCompanionClientTest.kt
@@ -22,9 +22,7 @@ class BotCompanionClientTest {
     @Test
     fun `should get characters`(wireMockRuntimeInfo: WireMockRuntimeInfo) {
 
-        val wireMock = wireMockRuntimeInfo.wireMock
-
-        wireMock.register(
+        wireMockRuntimeInfo.wireMock.register(
             WireMock.get("/v-rising-discord-bot/characters")
                 .willReturn(
                     WireMock.aResponse()
@@ -61,12 +59,10 @@ class BotCompanionClientTest {
     @Test
     fun `should get characters with basic authentication`(wireMockRuntimeInfo: WireMockRuntimeInfo) {
 
-        val wireMock = wireMockRuntimeInfo.wireMock
-
         val username = "test"
         val password = "password"
 
-        wireMock.register(
+        wireMockRuntimeInfo.wireMock.register(
             WireMock.get("/v-rising-discord-bot/characters")
                 .withBasicAuth(username, password)
                 .willReturn(
@@ -109,9 +105,7 @@ class BotCompanionClientTest {
     @Test
     fun `should handle errors getting characters`(wireMockRuntimeInfo: WireMockRuntimeInfo) {
 
-        val wireMock = wireMockRuntimeInfo.wireMock
-
-        wireMock.register(
+        wireMockRuntimeInfo.wireMock.register(
             WireMock.get("/v-rising-discord-bot/characters")
                 .willReturn(
                     WireMock.aResponse()


### PR DESCRIPTION
The bot now requests `info`, `players` and `rules` in parallel.