### PR TITLE
feat: improve logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>de.darkatra</groupId>
     <artifactId>v-rising-discord-bot</artifactId>
-    <version>2.9.5</version>
+    <version>2.10.0</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/src/main/kotlin/de/darkatra/vrising/discord/commands/GetServerDetailsCommand.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/commands/GetServerDetailsCommand.kt
@@ -160,7 +160,7 @@ class GetServerDetailsCommand(
                     value = when (serverStatusMonitor.recentErrors.isEmpty()) {
                         true -> "-"
                         false -> serverStatusMonitor.recentErrors.joinToString("\n") {
-                            "${it.timestamp}```${StringUtils.truncate(it.message, botProperties.maxCharactersPerError)}```"
+                            "<t:${it.timestamp}:R>```${StringUtils.truncate(it.message, botProperties.maxCharactersPerError)}```"
                         }
                     }
                 }

--- a/src/main/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationService.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationService.kt
@@ -92,7 +92,7 @@ class DatabaseMigrationService(
                         }
                     }
                 } else {
-                    document["recentErrors"] = emptyList<Error>()
+                    document["recentErrors"] = emptyList<Any>()
                 }
             }
         )

--- a/src/main/kotlin/de/darkatra/vrising/discord/serverstatus/ServerStatusMonitorService.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/serverstatus/ServerStatusMonitorService.kt
@@ -17,6 +17,7 @@ import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.embed
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -32,6 +33,9 @@ class ServerStatusMonitorService(
 
     suspend fun updateServerStatusMonitors(kord: Kord) {
         serverStatusMonitorRepository.getServerStatusMonitors(status = ServerStatusMonitorStatus.ACTIVE).forEach { serverStatusMonitor ->
+
+            MDC.put("server-status-monitor-id", serverStatusMonitor.id)
+
             updateServerStatusMonitor(kord, serverStatusMonitor)
             updatePlayerActivityFeed(kord, serverStatusMonitor)
             updatePvpKillFeed(kord, serverStatusMonitor)
@@ -40,6 +44,8 @@ class ServerStatusMonitorService(
             } catch (e: OutdatedServerStatusMonitorException) {
                 logger.debug("Server status monitor was updated or deleted by another thread. Will ignore this exception and proceed as usual.", e)
             }
+
+            MDC.clear()
         }
     }
 
@@ -110,7 +116,7 @@ class ServerStatusMonitorService(
                         add(
                             Error(
                                 message = "${e::class.simpleName}: ${e.message}",
-                                timestamp = Instant.now().toString()
+                                timestamp = Instant.now().epochSecond
                             )
                         )
                     }

--- a/src/main/kotlin/de/darkatra/vrising/discord/serverstatus/model/Error.kt
+++ b/src/main/kotlin/de/darkatra/vrising/discord/serverstatus/model/Error.kt
@@ -2,5 +2,5 @@ package de.darkatra.vrising.discord.serverstatus.model
 
 data class Error(
     val message: String,
-    val timestamp: String
+    val timestamp: Long
 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,5 +7,7 @@ logging:
   level:
     root: info
     com.ibasco.agql: warn
+  pattern:
+    console: "%clr(%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}){faint} %clr(%5p) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m %mdc%n%wEx"
 
 version: @project.version@

--- a/src/test/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationServiceTest.kt
+++ b/src/test/kotlin/de/darkatra/vrising/discord/migration/DatabaseMigrationServiceTest.kt
@@ -48,16 +48,17 @@ class DatabaseMigrationServiceTest {
         repository.insert(Schema(appVersion = "V2.2.0"))
         repository.insert(Schema(appVersion = "V2.3.0"))
         repository.insert(Schema(appVersion = "V2.9.0"))
+        repository.insert(Schema(appVersion = "V2.10.0"))
 
         val databaseMigrationService = DatabaseMigrationService(
             database = database,
-            appVersionFromPom = "2.9.0"
+            appVersionFromPom = "2.10.0"
         )
 
         assertThat(databaseMigrationService.migrateToLatestVersion()).isFalse()
 
         val schemas = repository.find().toList()
-        assertThat(schemas).hasSize(7)
+        assertThat(schemas).hasSize(8)
     }
 
     @Test


### PR DESCRIPTION
Errors in `/get-server-details` now display timestamps using [discords timestamp syntax](https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa#formatting), e.g. `<t:${timestamp}:R>`.  `Error#timestamp` is now of type `Long` instead of `String`. Old entries will be migrated automatically.

Logs now print the `MDC` to the console. Right now only the `server-status-monitor-id` is added to the `MDC` when a server status monitor is processed. This should simplify debugging exceptions.